### PR TITLE
feat: ✨ fix tag cloud overflow on mobile

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,6 +6,7 @@
       "Bash(gh api *)",
       "Bash(gh run *)",
       "Bash(task build:css)",
+      "Bash(task format *)",
       "Bash(task stop *)",
       "Bash(task test *)",
       "Bash(task test:headless)",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,6 +54,7 @@
     "Fukushima",
     "funcs",
     "getenv",
+    "getifaddr",
     "gitsecret",
     "goldmark",
     "hashnode",

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ task: Available tasks for this project:
 * outdated:                  点検 - 依存パッケージの更新を確認
 * restart:                   再起 - Hugo開発サーバーを再起動
 * setup:                     初回 - 初期セットアップ
-* start:                     開始 - Hugo開発サーバー起動      (aliases: dev)
+* start:                     開始 - Hugo開発サーバー起動（LAN内スマホからもアクセス可）      (aliases: dev)
 * stop:                      停止 - Hugo開発サーバーを全て停止
 * test:                      試験 - ローカルサーバーでPlaywrightテスト実行
 * build:css:                 構築 - TailwindCSSをビルド

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,13 +73,16 @@ tasks:
       - hugo --minify
 
   start:
-    desc: 開始 - Hugo開発サーバー起動
+    desc: 開始 - Hugo開発サーバー起動（LAN内スマホからもアクセス可）
     aliases:
       - dev
+    vars:
+      LOCAL_IP:
+        sh: ipconfig getifaddr en0 2>/dev/null || echo "localhost"
     deps:
       - build:css
     cmds:
-      - hugo server --buildDrafts --buildFuture
+      - hugo server --buildDrafts --buildFuture --bind 0.0.0.0 --baseURL http://{{.LOCAL_IP}}:1313/
 
   stop:
     desc: 停止 - Hugo開発サーバーを全て停止

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -86,3 +86,14 @@ html.dark::view-transition {
     transform: scale(1);
   }
 }
+
+/* overflow:hidden (from the overflow-hidden Tailwind class on the element) creates
+   a BFC — absolutely-positioned children are clipped at layout time and cannot
+   expand document scrollWidth on any browser including iOS Safari/WebKit.
+   overflow:clip (no BFC) would allow children to contribute to document scroll
+   in WebKit, so we must not override the Tailwind class here.
+   Height uses clamp() for responsive sizing: 240px floor for mobile portrait,
+   320px ceiling from tablet-width upward (50vw reaches 320 at 640px viewport). */
+#tag-cloud {
+  height: clamp(240px, 50vw, 320px);
+}

--- a/assets/js/tag-cloud.ts
+++ b/assets/js/tag-cloud.ts
@@ -89,35 +89,29 @@ function radialPositions(
   return positions
 }
 
-// ── Init ───────────────────────────────────────────────────────────────────────
-function initTagCloud(): void {
-  injectTagCloudStyle()
+type TagData = { name: string; count: number; url: string }
 
-  const container = document.getElementById("tag-cloud")
-  if (!container) return
+// ── Render ─────────────────────────────────────────────────────────────────────
+// Extracted so ResizeObserver can re-invoke without re-parsing data attributes.
+function renderTagCloud(
+  container: HTMLElement,
+  data: TagData[],
+  activeTag: string,
+  pinnedTags: string[]
+): void {
+  container.replaceChildren()
 
-  const raw = container.dataset.tags
-  if (!raw) return
+  // clientWidth excludes scrollbar width — more accurate than offsetWidth here
+  const containerW = container.clientWidth
+  const containerH = container.clientHeight
+  if (containerW === 0 || containerH === 0) return
 
-  const parsed: unknown = JSON.parse(raw)
-  if (!Array.isArray(parsed) || parsed.length === 0) return
-  const data = parsed as Array<{ name: string; count: number; url: string }>
-
-  const activeTag = (container.dataset.activeTag ?? "").toLowerCase()
-
-  // pinnedCenterTags is configured in config/_default/params.toml [tagCloud]
-  const rawPinned = container.dataset.pinnedTags
-  const pinnedTags: string[] = rawPinned
-    ? (JSON.parse(rawPinned) as string[]).map((s) => s.toLowerCase())
-    : []
+  const safeHalfW = (containerW / 2) * (1 - 2 * MARGIN)
+  const safeHalfH = (containerH / 2) * (1 - 2 * MARGIN)
 
   const counts = data.map((d) => d.count)
   const minCount = Math.min(...counts)
   const maxCount = Math.max(...counts)
-
-  const containerW = container.offsetWidth
-  const containerH = container.offsetHeight
-  if (containerW === 0 || containerH === 0) return
 
   const positions = radialPositions(
     data,
@@ -127,8 +121,6 @@ function initTagCloud(): void {
     activeTag
   )
 
-  container.style.position = "relative"
-
   for (const [i, d] of data.entries()) {
     const isActive = d.name.toLowerCase() === activeTag
     const isPinned = pinnedTags.includes(d.name.toLowerCase())
@@ -136,10 +128,21 @@ function initTagCloud(): void {
     el.href = d.url
     el.textContent = d.name
 
+    // Clamp each tag's center offset to the safe area so no tag can escape the
+    // container boundary regardless of GPU compositor clipping behaviour.
+    const clampedX = Math.max(
+      -safeHalfW,
+      Math.min(safeHalfW, positions[i].baseX)
+    )
+    const clampedY = Math.max(
+      -safeHalfH,
+      Math.min(safeHalfH, positions[i].baseY)
+    )
+
     // Baking scale() into the same transform property as the positioning translate
     // ensures transform-origin: 50% 50% resolves to the element's visual center,
     // so hover scale always expands from the tag's midpoint without shifting it.
-    const baseTransform = `translate(calc(-50% + ${positions[i].baseX.toFixed(1)}px), calc(-50% + ${positions[i].baseY.toFixed(1)}px))`
+    const baseTransform = `translate(calc(-50% + ${clampedX.toFixed(1)}px), calc(-50% + ${clampedY.toFixed(1)}px))`
 
     el.style.cssText = [
       "position:absolute",
@@ -153,7 +156,23 @@ function initTagCloud(): void {
       "transition:color 0.15s, transform 0.22s cubic-bezier(0.34,1.56,0.64,1)",
       "color:inherit",
     ].join(";")
-    el.style.fontSize = `${tagFontSize(d.count, minCount, maxCount, isPinned, isActive).toFixed(1)}px`
+    const baseFontSize = tagFontSize(
+      d.count,
+      minCount,
+      maxCount,
+      isPinned,
+      isActive
+    )
+    // Active tag sits at center (offsetX≈0) with white-space:nowrap, so its full
+    // text width must fit within the container. Cap using ~0.58× char-width ratio
+    // for the sans-serif font; floor at FONT_MIN so it never becomes illegible.
+    const fontSize = isActive
+      ? Math.max(
+          FONT_MIN,
+          Math.min(baseFontSize, (containerW * 0.88) / (d.name.length * 0.58))
+        )
+      : baseFontSize
+    el.style.fontSize = `${fontSize.toFixed(1)}px`
     el.style.transform = baseTransform
 
     if (isActive) {
@@ -177,6 +196,37 @@ function initTagCloud(): void {
 
     container.appendChild(el)
   }
+}
+
+// ── Init ───────────────────────────────────────────────────────────────────────
+function initTagCloud(): void {
+  injectTagCloudStyle()
+
+  const container = document.getElementById("tag-cloud")
+  if (!container) return
+
+  const raw = container.dataset.tags
+  if (!raw) return
+
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed) || parsed.length === 0) return
+  const data = parsed as TagData[]
+
+  const activeTag = (container.dataset.activeTag ?? "").toLowerCase()
+
+  // pinnedCenterTags is configured in config/_default/params.toml [tagCloud]
+  const rawPinned = container.dataset.pinnedTags
+  const pinnedTags: string[] = rawPinned
+    ? (JSON.parse(rawPinned) as string[]).map((s) => s.toLowerCase())
+    : []
+
+  renderTagCloud(container, data, activeTag, pinnedTags)
+
+  // Re-render on container resize to handle orientation changes and layout shifts.
+  const observer = new ResizeObserver(() => {
+    renderTagCloud(container, data, activeTag, pinnedTags)
+  })
+  observer.observe(container)
 }
 
 if (document.readyState === "loading") {

--- a/layouts/partials/tag-cloud.html
+++ b/layouts/partials/tag-cloud.html
@@ -13,7 +13,6 @@
     data-active-tag="{{ $activeTag }}"
     data-pinned-tags="{{ $pinnedTags | jsonify }}"
     class="relative my-8 overflow-hidden"
-    style="height: 320px;"
     aria-label="Tag cloud"
   ></div>
 {{ end }}

--- a/tests/posts.en.spec.ts
+++ b/tests/posts.en.spec.ts
@@ -45,4 +45,21 @@ test.describe("posts en", () => {
     await page.waitForTimeout(500)
     expect(errors).toHaveLength(0)
   })
+
+  test("tag cloud container stays within viewport", async ({ page }) => {
+    await page.goto("/posts/")
+    await page.waitForTimeout(300)
+    const overflow = await page.evaluate(() => {
+      const cloud = document.getElementById("tag-cloud")
+      if (!cloud) return -1
+      const rect = cloud.getBoundingClientRect()
+      const internalScroll = cloud.scrollWidth - cloud.clientWidth
+      const externalOverflow = Math.max(
+        0,
+        rect.right - document.documentElement.clientWidth
+      )
+      return internalScroll + externalOverflow
+    })
+    expect(overflow).toBe(0)
+  })
 })

--- a/tests/posts.ja.spec.ts
+++ b/tests/posts.ja.spec.ts
@@ -45,4 +45,21 @@ test.describe("posts ja", () => {
     await page.waitForTimeout(500)
     expect(errors).toHaveLength(0)
   })
+
+  test("tag cloud container stays within viewport", async ({ page }) => {
+    await page.goto("/ja/posts/")
+    await page.waitForTimeout(300)
+    const overflow = await page.evaluate(() => {
+      const cloud = document.getElementById("tag-cloud")
+      if (!cloud) return -1
+      const rect = cloud.getBoundingClientRect()
+      const internalScroll = cloud.scrollWidth - cloud.clientWidth
+      const externalOverflow = Math.max(
+        0,
+        rect.right - document.documentElement.clientWidth
+      )
+      return internalScroll + externalOverflow
+    })
+    expect(overflow).toBe(0)
+  })
 })

--- a/tests/tags.en.spec.ts
+++ b/tests/tags.en.spec.ts
@@ -47,4 +47,21 @@ test.describe("tags en", () => {
     await page.waitForTimeout(500)
     expect(errors).toHaveLength(0)
   })
+
+  test("tag cloud container stays within viewport", async ({ page }) => {
+    await page.goto("/tags/works/")
+    await page.waitForTimeout(300)
+    const overflow = await page.evaluate(() => {
+      const cloud = document.getElementById("tag-cloud")
+      if (!cloud) return -1
+      const rect = cloud.getBoundingClientRect()
+      const internalScroll = cloud.scrollWidth - cloud.clientWidth
+      const externalOverflow = Math.max(
+        0,
+        rect.right - document.documentElement.clientWidth
+      )
+      return internalScroll + externalOverflow
+    })
+    expect(overflow).toBe(0)
+  })
 })

--- a/tests/tags.ja.spec.ts
+++ b/tests/tags.ja.spec.ts
@@ -47,4 +47,23 @@ test.describe("tags ja", () => {
     await page.waitForTimeout(500)
     expect(errors).toHaveLength(0)
   })
+
+  test("tag cloud container stays within viewport", async ({ page }) => {
+    await page.goto("/ja/tags/works/")
+    await page.waitForTimeout(300)
+    const overflow = await page.evaluate(() => {
+      const cloud = document.getElementById("tag-cloud")
+      if (!cloud) return -1
+      const rect = cloud.getBoundingClientRect()
+      // Internal scroll: tags must be clipped by overflow:hidden
+      const internalScroll = cloud.scrollWidth - cloud.clientWidth
+      // External position: container must not extend beyond viewport
+      const externalOverflow = Math.max(
+        0,
+        rect.right - document.documentElement.clientWidth
+      )
+      return internalScroll + externalOverflow
+    })
+    expect(overflow).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary

- `#tag-cloud` コンテナの高さをレスポンシブ化（`clamp(240px, 50vw, 320px)`）し、インライン `style="height: 320px;"` を削除
- `tag-cloud.ts` をリファクタリングし `renderTagCloud()` を分離、`ResizeObserver` でデバイス回転時も再描画するよう対応
- タグの位置クランプを追加し、絶対配置要素がコンテナ境界を超えないよう保証
- アクティブタグ（中央配置）のフォントサイズを文字幅推定でキャップし、長いタグ名がコンテナを突き抜けないよう制御
- `task start` に `--bind 0.0.0.0 --baseURL` を追加し、LAN 内スマホからの実機確認を可能に

## Test plan

- [x] `task test:headless` — 380件全テスト通過
- [x] 各テストファイルに `tag cloud container stays within viewport` テストを追加（`getBoundingClientRect` + `scrollWidth` で tag cloud コンテナ固有のオーバーフローを検証）
- [x] スマホ実機（iOS Safari）で `/posts/` および `/tags/*` を目視確認

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Hugo開発サーバーをLAN内のスマートフォンからアクセス可能に設定しました。

* **バグ修正**
  * タグクラウドがビューポート外にはみ出さないよう改善しました。
  * タグクラウドをレスポンシブ対応にし、画面サイズに応じた最適な高さで表示するようにしました。

* **テスト**
  * タグクラウドがビューポート内に正しく収まることを検証するテストを追加しました。

* **その他**
  * 設定ファイルを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sforzando/sfz.dev/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->